### PR TITLE
v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-# 0.1.3
+# 0.1.4
+
+- Derry now uses `lint` instead of `pedantic` as code linter & analyzer
+- Code base is now formatted according to the `lint`'s rules
+- Use `stdout` and `stderr` instead of `print`
+
+## 0.1.3
 
 - Add support for nested subcommands like `$generate:env` to run as `derry generate env`
 - Add support for `derry update` command

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,1 +1,1 @@
-include: package:pedantic/analysis_options.yaml
+include: package:lint/analysis_options.yaml

--- a/bin/derry.dart
+++ b/bin/derry.dart
@@ -23,8 +23,8 @@ Future<void> executeDerry(List<String> arguments) async {
 
   final argResults = runner.parse(arguments);
 
-  if (argResults['version'] != null) {
-    stdout.write('derry version: $packageVersion');
+  if (argResults['version'] as bool) {
+    stdout.writeln('derry version: $packageVersion');
   } else {
     try {
       await runner.run(arguments);
@@ -35,7 +35,7 @@ Future<void> executeDerry(List<String> arguments) async {
           error.message.startsWith('Could not find a command named')) {
         await executeDerry(['run', ...arguments]);
       } else {
-        stderr.write(error);
+        stderr.writeln(error);
         exit(1);
       }
     }

--- a/bin/derry.dart
+++ b/bin/derry.dart
@@ -1,4 +1,4 @@
-import 'dart:io';
+import 'dart:io' show stdout, stderr, exit;
 import 'package:derry/derry.dart';
 import 'package:args/command_runner.dart';
 
@@ -23,8 +23,8 @@ Future<void> executeDerry(List<String> arguments) async {
 
   final argResults = runner.parse(arguments);
 
-  if (argResults['version']) {
-    print('derry version: $packageVersion');
+  if (argResults['version'] != null) {
+    stdout.write('derry version: $packageVersion');
   } else {
     try {
       await runner.run(arguments);
@@ -35,7 +35,7 @@ Future<void> executeDerry(List<String> arguments) async {
           error.message.startsWith('Could not find a command named')) {
         await executeDerry(['run', ...arguments]);
       } else {
-        print(error);
+        stderr.write(error);
         exit(1);
       }
     }

--- a/lib/derry.dart
+++ b/lib/derry.dart
@@ -1,5 +1,6 @@
 library derry;
 
+import 'dart:cli' as cli;
 import 'dart:ffi'
     show
         Int32,
@@ -10,45 +11,44 @@ import 'dart:ffi'
         NativeFunction,
         DynamicLibrary,
         NativeFunctionPointer;
-import 'dart:cli' as cli;
+import 'dart:io' show Platform, File, Directory, stdout, stderr;
 import 'dart:isolate' show Isolate;
-import 'dart:io' show Platform, File, Directory;
 
-import 'package:yaml/yaml.dart';
-import 'package:ffi/ffi.dart' show Utf8;
-import 'package:console/console.dart' show format;
 import 'package:args/command_runner.dart' show Command;
+import 'package:console/console.dart' show format;
 import 'package:equatable/equatable.dart' show Equatable;
+import 'package:ffi/ffi.dart' show Utf8;
 import 'package:string_similarity/string_similarity.dart';
+import 'package:yaml/yaml.dart';
 
 import 'src/version.dart';
 export 'src/version.dart';
 
-part 'src/config.dart';
-part 'src/execute.dart';
-part 'src/load_info.dart';
-part 'src/find_source.dart';
-part 'src/load_definitions.dart';
-
 part 'src/bindings/executor.dart';
 part 'src/bindings/get_object.dart';
 
-part 'src/error/handler.dart';
-part 'src/error/error_type.dart';
-
 part 'src/commands/ls.dart';
 part 'src/commands/run.dart';
-part 'src/commands/update.dart';
 part 'src/commands/source.dart';
+part 'src/commands/update.dart';
 
-part 'src/models/info.dart';
-part 'src/models/error.dart';
-part 'src/models/definition.dart';
+part 'src/config.dart';
+part 'src/error/error_type.dart';
+part 'src/error/handler.dart';
+part 'src/execute.dart';
+part 'src/find_source.dart';
 
-part 'src/helpers/to_list.dart';
-part 'src/helpers/make_keys.dart';
-part 'src/helpers/subcommand.dart';
 part 'src/helpers/deep_search.dart';
+part 'src/helpers/make_keys.dart';
+part 'src/helpers/parse_defnintion.dart';
 part 'src/helpers/read_pubspec.dart';
 part 'src/helpers/read_yaml_file.dart';
-part 'src/helpers/parse_defnintion.dart';
+part 'src/helpers/subcommand.dart';
+part 'src/helpers/to_list.dart';
+
+part 'src/load_definitions.dart';
+part 'src/load_info.dart';
+
+part 'src/models/definition.dart';
+part 'src/models/error.dart';
+part 'src/models/info.dart';

--- a/lib/src/bindings/executor.dart
+++ b/lib/src/bindings/executor.dart
@@ -3,8 +3,9 @@ part of derry;
 typedef executor_fn = Void Function(Pointer<Utf8>, Int32);
 typedef Executor = void Function(Pointer<Utf8>, int);
 
+// ignore: avoid_positional_boolean_parameters
 void executor(String input, bool silent) {
-  final rootLibrary = 'package:derry/derry.dart';
+  const rootLibrary = 'package:derry/derry.dart';
   final blobs = cli
       .waitFor(Isolate.resolvePackageUri(Uri.parse(rootLibrary)))
       .resolve('src/blobs/');

--- a/lib/src/bindings/get_object.dart
+++ b/lib/src/bindings/get_object.dart
@@ -20,7 +20,7 @@ String getObject() {
     extension = 'dll';
   } else {
     throw Error(
-      type: ErrorType.PNS,
+      type: ErrorType.pns,
       body: {'os': Platform.operatingSystem},
     );
   }
@@ -28,7 +28,7 @@ String getObject() {
   final result = os + architecture;
   if (!supported.contains(result)) {
     throw Error(
-      type: ErrorType.PNS,
+      type: ErrorType.pns,
       body: {'architecture': result},
     );
   }

--- a/lib/src/commands/ls.dart
+++ b/lib/src/commands/ls.dart
@@ -33,15 +33,15 @@ class ListCommand extends Command {
           ),
     );
 
-    print(infoLine);
-    print('│');
+    stdout.write(infoLine);
+    stdout.write('│');
 
     for (final entry in keys.asMap().entries) {
       final i = entry.key;
       final value = entry.value;
       final subcommands = mapping[entry.key];
 
-      print('${getPrefix(i, keys.length)} $value');
+      stdout.write('${getPrefix(i, keys.length)} $value');
 
       for (final subEntry in subcommands.asMap().entries) {
         final j = subEntry.key;
@@ -49,8 +49,9 @@ class ListCommand extends Command {
           '{color.green}${subEntry.value.replaceAll('\\\$', '\$').split(':').join(' ')}{color.end}',
         );
 
-        print(
-            '${i == keys.length - 1 ? ' ' : '│'}   ${getPrefix(j, subcommands.length)} $subValue');
+        stdout.write(
+          '${i == keys.length - 1 ? ' ' : '│'}   ${getPrefix(j, subcommands.length)} $subValue',
+        );
       }
     }
   }

--- a/lib/src/commands/ls.dart
+++ b/lib/src/commands/ls.dart
@@ -33,15 +33,15 @@ class ListCommand extends Command {
           ),
     );
 
-    stdout.write(infoLine);
-    stdout.write('│');
+    stdout.writeln(infoLine);
+    stdout.writeln('│');
 
     for (final entry in keys.asMap().entries) {
       final i = entry.key;
       final value = entry.value;
       final subcommands = mapping[entry.key];
 
-      stdout.write('${getPrefix(i, keys.length)} $value');
+      stdout.writeln('${getPrefix(i, keys.length)} $value');
 
       for (final subEntry in subcommands.asMap().entries) {
         final j = subEntry.key;
@@ -49,7 +49,7 @@ class ListCommand extends Command {
           '{color.green}${subEntry.value.replaceAll('\\\$', '\$').split(':').join(' ')}{color.end}',
         );
 
-        stdout.write(
+        stdout.writeln(
           '${i == keys.length - 1 ? ' ' : '│'}   ${getPrefix(j, subcommands.length)} $subValue',
         );
       }

--- a/lib/src/commands/run.dart
+++ b/lib/src/commands/run.dart
@@ -15,7 +15,6 @@ class RunCommmand extends Command {
           'silent',
           abbr: 's',
           help: 'determine whether to show outputs or not',
-          defaultsTo: false,
           negatable: false,
         );
   }
@@ -40,12 +39,12 @@ class RunCommmand extends Command {
   @override
   Future<void> run() async {
     final parsed = parseExtras(super.argResults.arguments);
-    final args = super.argParser.parse(parsed['args']).rest;
-    final extra = parsed['extra'].join(' ');
-    final silent = super.argResults['silent'];
+    final args = super.argParser.parse(parsed['args'] as Iterable<String>).rest;
+    final extra = (parsed['extra'] as List<String>).join(' ');
+    final silent = super.argResults['silent'] as bool;
 
     if (args.isEmpty && !alias) {
-      print(super.usage);
+      stdout.write(super.usage);
     } else {
       final arg =
           alias ? '$name ${args.join(' ')}'.trim() : args.join(' ').trim();

--- a/lib/src/commands/run.dart
+++ b/lib/src/commands/run.dart
@@ -44,7 +44,7 @@ class RunCommmand extends Command {
     final silent = super.argResults['silent'] as bool;
 
     if (args.isEmpty && !alias) {
-      stdout.write(super.usage);
+      stdout.writeln(super.usage);
     } else {
       final arg =
           alias ? '$name ${args.join(' ')}'.trim() : args.join(' ').trim();

--- a/lib/src/commands/source.dart
+++ b/lib/src/commands/source.dart
@@ -13,7 +13,6 @@ class SourceCommand extends Command {
           'absolute',
           abbr: 'a',
           help: 'determine whether to show absolute paths or not',
-          defaultsTo: false,
           negatable: false,
         );
   }
@@ -22,10 +21,10 @@ class SourceCommand extends Command {
   Future<void> run() async {
     final absolute = super.argResults['absolute'];
 
-    if (absolute) {
-      print(File(await findSource()).absolute.path);
+    if (absolute != null) {
+      stdout.write(File(await findSource()).absolute.path);
     } else {
-      print(await findSource());
+      stdout.write(await findSource());
     }
   }
 }

--- a/lib/src/commands/source.dart
+++ b/lib/src/commands/source.dart
@@ -22,9 +22,9 @@ class SourceCommand extends Command {
     final absolute = super.argResults['absolute'];
 
     if (absolute != null) {
-      stdout.write(File(await findSource()).absolute.path);
+      stdout.writeln(File(await findSource()).absolute.path);
     } else {
-      stdout.write(await findSource());
+      stdout.writeln(await findSource());
     }
   }
 }

--- a/lib/src/commands/update.dart
+++ b/lib/src/commands/update.dart
@@ -11,7 +11,7 @@ class UpdateCommand extends Command {
   @override
   Future<void> run() async {
     {
-      final infoLine = '> derry@${packageVersion} update';
+      const infoLine = '> derry@$packageVersion update';
 
       execute(
         {'update': 'pub global activate derry'},

--- a/lib/src/error/error_type.dart
+++ b/lib/src/error/error_type.dart
@@ -5,33 +5,33 @@ part of derry;
 /// Types of error that can be handled.
 enum ErrorType {
   /// [SNF] = Script Not Found, throw when a particular script is not found
-  SNF,
+  snf,
 
   /// [DNF] = Definitions Not Found, throw when unable to locate definitions source
 
-  DNF,
+  dnf,
 
   /// [IET] = Incorrect Execution Type, throw when incorrect execution is configured
 
-  IET,
+  iet,
 
   /// [CPD] = Cannot Parse Definitions, throw when definitions are configured in incorrected format
 
-  CPD,
+  cpd,
 
   /// [FNF] = File Not Found, throw when a specific file cannot be located
 
-  FNF,
+  fnf,
 
   /// [CPY] = Cannot Parse YAML, throw when YAML format is incorrect
 
-  CPY,
+  cpy,
 
   /// [CCT] = Cannot Cast Type, throw when a type can't be casted into another
 
-  CCT,
+  cct,
 
   /// [PNS] = Platform Not Supported, throw when using on an unsupported platform
 
-  PNS,
+  pns,
 }

--- a/lib/src/error/handler.dart
+++ b/lib/src/error/handler.dart
@@ -3,56 +3,61 @@ part of derry;
 void errorHandler(Error t) {
   final prefixer = format('derry {color.red}ERROR!{color.end}');
 
-  print('$prefixer ${t.type.toString().replaceAll('ErrorType.', '')}');
+  stderr.write('$prefixer ${t.type.toString().replaceAll('ErrorType.', '')}');
 
   switch (t.type) {
-    case ErrorType.SNF:
-      final String mainScript = t.body['script'];
+    case ErrorType.snf:
+      final mainScript = t.body['script'] as String;
       final definitions = t.body['definitions'] as List<String>;
 
-      print('$prefixer Unable to find script named "$mainScript".');
-      print('');
+      stderr.write('$prefixer Unable to find script named "$mainScript".');
+      stderr.write('');
 
-      final bestMatch =
-          StringSimilarity.findBestMatch(mainScript, definitions).bestMatch;
+      final bestMatch = StringSimilarity.findBestMatch(
+        mainScript,
+        definitions,
+      ).bestMatch;
 
       if (bestMatch.rating >= 0.5) {
-        print('$prefixer Did you mean this?');
-        print('$prefixer    ${bestMatch.target}');
+        stderr.write('$prefixer Did you mean this?');
+        stderr.write('$prefixer    ${bestMatch.target}');
       }
       break;
-    case ErrorType.DNF:
-      print('$prefixer Unable to find definitions.');
+    case ErrorType.dnf:
+      stderr.write('$prefixer Unable to find definitions.');
       break;
-    case ErrorType.IET:
-      print('$prefixer Unable to parse definitions.');
-      print(
+    case ErrorType.iet:
+      stderr.write('$prefixer Unable to parse definitions.');
+      stderr.write(
         '$prefixer The definitions are not correctly defined in the right format.',
       );
       break;
-    case ErrorType.PNS:
-      print('$prefixer Unsupported plaform.');
+    case ErrorType.pns:
+      stderr.write('$prefixer Unsupported plaform.');
       if (t.body.containsKey('os')) {
-        print('$prefixer Unsupported operating system "${t.body['os']}".');
+        stderr.write(
+          '$prefixer Unsupported operating system "${t.body['os']}".',
+        );
       } else if (t.body.containsKey('architecture')) {
-        print(
-            '$prefixer Unsupported architecture "${t.body['architecture']}".');
+        stderr.write(
+          '$prefixer Unsupported architecture "${t.body['architecture']}".',
+        );
       }
       break;
-    case ErrorType.CPY:
-      print('$prefixer Incorrect YAML format.');
+    case ErrorType.cpy:
+      stderr.write('$prefixer Incorrect YAML format.');
       break;
-    case ErrorType.CPD:
-      print('$prefixer Incorrect definition format.');
+    case ErrorType.cpd:
+      stderr.write('$prefixer Incorrect definition format.');
       break;
-    case ErrorType.CCT:
-      print('$prefixer Unable to cast to type required.');
-      print(
+    case ErrorType.cct:
+      stderr.write('$prefixer Unable to cast to type required.');
+      stderr.write(
         '$prefixer "${t.body['from']}" can\'t be casted into "${t.body['to']}"',
       );
       break;
-    case ErrorType.FNF:
-      print('$prefixer File Not Found at "${t.body['path']}"');
+    case ErrorType.fnf:
+      stderr.write('$prefixer File Not Found at "${t.body['path']}"');
       break;
   }
 }

--- a/lib/src/error/handler.dart
+++ b/lib/src/error/handler.dart
@@ -3,15 +3,15 @@ part of derry;
 void errorHandler(Error t) {
   final prefixer = format('derry {color.red}ERROR!{color.end}');
 
-  stderr.write('$prefixer ${t.type.toString().replaceAll('ErrorType.', '')}');
+  stderr.writeln('$prefixer ${t.type.toString().replaceAll('ErrorType.', '')}');
 
   switch (t.type) {
     case ErrorType.snf:
       final mainScript = t.body['script'] as String;
       final definitions = t.body['definitions'] as List<String>;
 
-      stderr.write('$prefixer Unable to find script named "$mainScript".');
-      stderr.write('');
+      stderr.writeln('$prefixer Unable to find script named "$mainScript".');
+      stderr.writeln('');
 
       final bestMatch = StringSimilarity.findBestMatch(
         mainScript,
@@ -19,45 +19,45 @@ void errorHandler(Error t) {
       ).bestMatch;
 
       if (bestMatch.rating >= 0.5) {
-        stderr.write('$prefixer Did you mean this?');
-        stderr.write('$prefixer    ${bestMatch.target}');
+        stderr.writeln('$prefixer Did you mean this?');
+        stderr.writeln('$prefixer    ${bestMatch.target}');
       }
       break;
     case ErrorType.dnf:
-      stderr.write('$prefixer Unable to find definitions.');
+      stderr.writeln('$prefixer Unable to find definitions.');
       break;
     case ErrorType.iet:
-      stderr.write('$prefixer Unable to parse definitions.');
-      stderr.write(
+      stderr.writeln('$prefixer Unable to parse definitions.');
+      stderr.writeln(
         '$prefixer The definitions are not correctly defined in the right format.',
       );
       break;
     case ErrorType.pns:
-      stderr.write('$prefixer Unsupported plaform.');
+      stderr.writeln('$prefixer Unsupported plaform.');
       if (t.body.containsKey('os')) {
-        stderr.write(
+        stderr.writeln(
           '$prefixer Unsupported operating system "${t.body['os']}".',
         );
       } else if (t.body.containsKey('architecture')) {
-        stderr.write(
+        stderr.writeln(
           '$prefixer Unsupported architecture "${t.body['architecture']}".',
         );
       }
       break;
     case ErrorType.cpy:
-      stderr.write('$prefixer Incorrect YAML format.');
+      stderr.writeln('$prefixer Incorrect YAML format.');
       break;
     case ErrorType.cpd:
-      stderr.write('$prefixer Incorrect definition format.');
+      stderr.writeln('$prefixer Incorrect definition format.');
       break;
     case ErrorType.cct:
-      stderr.write('$prefixer Unable to cast to type required.');
-      stderr.write(
+      stderr.writeln('$prefixer Unable to cast to type required.');
+      stderr.writeln(
         '$prefixer "${t.body['from']}" can\'t be casted into "${t.body['to']}"',
       );
       break;
     case ErrorType.fnf:
-      stderr.write('$prefixer File Not Found at "${t.body['path']}"');
+      stderr.writeln('$prefixer File Not Found at "${t.body['path']}"');
       break;
   }
 }

--- a/lib/src/execute.dart
+++ b/lib/src/execute.dart
@@ -12,7 +12,7 @@ void execute(
   /// for incomplete calls for nested scripts
   if (searchResult is YamlMap && !searchResult.value.containsKey('(scripts)')) {
     throw Error(
-      type: ErrorType.SNF,
+      type: ErrorType.snf,
       body: {
         'script': arg,
         'definitions': makeKeys(definitions),
@@ -22,7 +22,7 @@ void execute(
 
   final definition = parseDefinition(searchResult);
 
-  if (infoLine != null) print(infoLine);
+  if (infoLine != null) stdout.write(infoLine);
   switch (definition.execution) {
     case 'once':
       final script = definition.scripts.join(' && ');

--- a/lib/src/execute.dart
+++ b/lib/src/execute.dart
@@ -22,7 +22,7 @@ void execute(
 
   final definition = parseDefinition(searchResult);
 
-  if (infoLine != null) stdout.write(infoLine);
+  if (infoLine != null) stdout.writeln(infoLine);
   switch (definition.execution) {
     case 'once':
       final script = definition.scripts.join(' && ');

--- a/lib/src/find_source.dart
+++ b/lib/src/find_source.dart
@@ -6,7 +6,7 @@ Future<String> findSource() async {
   final definitions = pubspec.contents.value['scripts'];
 
   if (definitions == null) {
-    throw Error(type: ErrorType.DNF);
+    throw const Error(type: ErrorType.dnf);
   }
 
   if (definitions is YamlMap) {
@@ -15,11 +15,11 @@ Future<String> findSource() async {
     final fileScripts = await readYamlFile(definitions.toString());
 
     if (fileScripts.contents.value is YamlMap) {
-      return '$definitions';
+      return definitions;
     } else {
-      throw Error(type: ErrorType.CPD);
+      throw const Error(type: ErrorType.cpd);
     }
   } else {
-    throw Error(type: ErrorType.CPD);
+    throw const Error(type: ErrorType.cpd);
   }
 }

--- a/lib/src/helpers/deep_search.dart
+++ b/lib/src/helpers/deep_search.dart
@@ -2,22 +2,22 @@ part of derry;
 
 dynamic search(Map data, String key) {
   var d = data;
-  var current = '';
+  final current = StringBuffer();
   final keyPieces = key.split(' ');
 
   for (final entry in keyPieces.asMap().entries) {
     final i = entry.key;
     final k = entry.value;
 
-    current += '$k ';
+    current.write('$k ');
     if (d is Map && d.containsKey(k)) {
       if (i == keyPieces.length - 1) {
         return d[k];
       } else if (d[k] is Map) {
-        d = d[k];
+        d = d[k] as Map;
       } else {
         throw Error(
-          type: ErrorType.SNF,
+          type: ErrorType.snf,
           body: {
             'script': key.trim(),
             'definitions': makeKeys(data),
@@ -26,9 +26,9 @@ dynamic search(Map data, String key) {
       }
     } else {
       throw Error(
-        type: ErrorType.SNF,
+        type: ErrorType.snf,
         body: {
-          'script': current.trim(),
+          'script': current.toString().trim(),
           'definitions': makeKeys(data),
         },
       );

--- a/lib/src/helpers/parse_defnintion.dart
+++ b/lib/src/helpers/parse_defnintion.dart
@@ -3,12 +3,11 @@ part of derry;
 Definition parseDefinition(dynamic input) {
   if (input is YamlMap) {
     return Definition(
-      execution: input.value['(execution)'],
+      execution: input.value['(execution)'] as String,
       scripts: toList(input.value['(scripts)']),
     );
   } else {
     return Definition(
-      execution: 'multiple',
       scripts: toList(input),
     );
   }

--- a/lib/src/helpers/read_pubspec.dart
+++ b/lib/src/helpers/read_pubspec.dart
@@ -2,5 +2,5 @@ part of derry;
 
 /// read and return pubspec.yaml in current directory
 Future<YamlDocument> readPubspec() async {
-  return readYamlFile(Directory.current.path + '/pubspec.yaml');
+  return readYamlFile('${Directory.current.path}/pubspec.yaml');
 }

--- a/lib/src/helpers/read_yaml_file.dart
+++ b/lib/src/helpers/read_yaml_file.dart
@@ -7,7 +7,7 @@ Future<YamlDocument> readYamlFile(String filePath) async {
 
   if (!await file.exists()) {
     throw Error(
-      type: ErrorType.FNF,
+      type: ErrorType.fnf,
       body: {'path': filePath},
     );
   }
@@ -15,7 +15,7 @@ Future<YamlDocument> readYamlFile(String filePath) async {
   try {
     document = loadYamlDocument(await file.readAsString());
   } catch (e) {
-    throw Error(type: ErrorType.CPY);
+    throw const Error(type: ErrorType.cpy);
   }
 
   return document;

--- a/lib/src/helpers/to_list.dart
+++ b/lib/src/helpers/to_list.dart
@@ -7,7 +7,7 @@ List<String> toList(dynamic input) {
     return [input.toString()];
   } else {
     throw Error(
-      type: ErrorType.CCT,
+      type: ErrorType.cct,
       body: {
         'from': input.runtimeType,
         'to': 'List<String>',

--- a/lib/src/load_definitions.dart
+++ b/lib/src/load_definitions.dart
@@ -6,7 +6,7 @@ Future<Map> loadDefinitions() async {
   final definitions = pubspec.contents.value['scripts'];
 
   if (definitions == null) {
-    throw Error(type: ErrorType.DNF);
+    throw const Error(type: ErrorType.dnf);
   }
 
   if (definitions is YamlMap) {
@@ -15,11 +15,11 @@ Future<Map> loadDefinitions() async {
     final fileScripts = await readYamlFile(definitions.toString());
 
     if (fileScripts.contents.value is YamlMap) {
-      return fileScripts.contents.value;
+      return fileScripts.contents.value as Map;
     } else {
-      throw Error(type: ErrorType.CPD);
+      throw const Error(type: ErrorType.cpd);
     }
   } else {
-    throw Error(type: ErrorType.CPD);
+    throw const Error(type: ErrorType.cpd);
   }
 }

--- a/lib/src/load_info.dart
+++ b/lib/src/load_info.dart
@@ -3,8 +3,8 @@ part of derry;
 /// load package info from pubspec yaml content
 Future<Info> loadInfo() async {
   final pubspec = await readPubspec();
-  final name = pubspec.contents.value['name'];
-  final version = pubspec.contents.value['version'];
+  final name = pubspec.contents.value['name'] as String;
+  final version = pubspec.contents.value['version'] as String;
 
   return Info(name: name, version: version);
 }

--- a/lib/src/models/definition.dart
+++ b/lib/src/models/definition.dart
@@ -10,7 +10,7 @@ class Definition extends Equatable {
   final String execution;
   final List<String> scripts;
 
-  Definition({
+  const Definition({
     this.execution = 'multiple',
     this.scripts,
   });

--- a/lib/src/models/error.dart
+++ b/lib/src/models/error.dart
@@ -4,7 +4,7 @@ class Error extends Equatable {
   final ErrorType type;
   final Map<String, dynamic> body;
 
-  Error({
+  const Error({
     this.type,
     this.body,
   });

--- a/lib/src/models/info.dart
+++ b/lib/src/models/info.dart
@@ -5,7 +5,7 @@ class Info extends Equatable {
   final String name;
   final String version;
 
-  Info({
+  const Info({
     this.name,
     this.version,
   });

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.3';
+const packageVersion = '0.1.4';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: derry
 description: Derry is a script manager for Dart. It helps you define script shortcuts and use them effortlessly, and performantly as it should be.
-version: 0.1.3
+version: 0.1.4
 homepage: https://github.com/frencojobs/derry
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
 
 dev_dependencies:
   test: ^1.6.0
-  pedantic: ^1.8.0
+  lint: ^1.3.0
   build_runner: ^1.10.0
   build_version: ^2.0.1
 

--- a/test/helpers_test.dart
+++ b/test/helpers_test.dart
@@ -18,14 +18,14 @@ void main() {
     test('load_info should return proper results', () async {
       expect(
         await loadInfo(),
-        equals(Info(name: 'derry', version: packageVersion)),
+        equals(const Info(name: 'derry', version: packageVersion)),
       );
     });
 
     test('parse_definition should return expected outputs', () {
       expect(
         parseDefinition('echo 0'),
-        equals(Definition(execution: 'multiple', scripts: ['echo 0'])),
+        equals(const Definition(scripts: ['echo 0'])),
       );
     });
 
@@ -36,13 +36,13 @@ void main() {
       );
     });
 
-    test('read_yaml_file should fail when there\'s not a file', () {
+    test("read_yaml_file should fail when there's not a file", () {
       expect(
-        () async => await readYamlFile('yaml'),
+        () async => readYamlFile('yaml'),
         throwsA(
           equals(
-            Error(
-              type: ErrorType.FNF,
+            const Error(
+              type: ErrorType.fnf,
               body: {'path': 'yaml'},
             ),
           ),
@@ -52,10 +52,10 @@ void main() {
 
     test('read_yaml_file should fail when the file is not in yaml format', () {
       expect(
-        () async => await readYamlFile('README.md'),
+        () async => readYamlFile('README.md'),
         throwsA(
           equals(
-            Error(type: ErrorType.CPY),
+            const Error(type: ErrorType.cpy),
           ),
         ),
       );
@@ -66,9 +66,12 @@ void main() {
         () => toList(null),
         throwsA(
           equals(
-            Error(
-              type: ErrorType.CCT,
-              body: {'from': Null, 'to': 'List<String>'},
+            const Error(
+              type: ErrorType.cct,
+              body: {
+                'from': Null,
+                'to': 'List<String>',
+              },
             ),
           ),
         ),


### PR DESCRIPTION
- Use `lint` instead of `pedantic` for linting
- Use `stdout` and `stderr` instead of `print`