### PR TITLE
v1.0.0 &  v1.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 0.1.4
+# 1.0.0
+
+- Today I learned how versioning system actually works
+
+## 0.1.4
 
 - Derry now uses `lint` instead of `pedantic` as code linter & analyzer
 - Code base is now formatted according to the `lint`'s rules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# 1.0.0
+## 1.0.1
+
+- Formatted changelogs according to pub.dev
+
+## 1.0.0
 
 - Today I learned how versioning system actually works
 

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '1.0.0';
+const packageVersion = '1.0.1';

--- a/lib/src/version.dart
+++ b/lib/src/version.dart
@@ -1,2 +1,2 @@
 // Generated code. Do not modify.
-const packageVersion = '0.1.4';
+const packageVersion = '1.0.0';

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: derry
 description: Derry is a script manager for Dart. It helps you define script shortcuts and use them effortlessly, and performantly as it should be.
-version: 0.1.4
+version: 1.0.0
 homepage: https://github.com/frencojobs/derry
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: derry
 description: Derry is a script manager for Dart. It helps you define script shortcuts and use them effortlessly, and performantly as it should be.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/frencojobs/derry
 
 environment:


### PR DESCRIPTION
- Release according to `semver`
- Format changelogs according to pub.dev
- Contains no changes at all